### PR TITLE
Don't add to the country count if multiple locations with the same country code exist.

### DIFF
--- a/src/components/locations/LocationPage.tsx
+++ b/src/components/locations/LocationPage.tsx
@@ -116,7 +116,13 @@ class LocationPage extends React.Component<ILocationPageProps> {
     computeCountriesVisited(locs: ITravelLocation[]): number {
         const today = new Date()
         let visited = 0;
+        let countryCodeSet = new Set();
         for (const loc of locs) {
+            if (countryCodeSet.has(loc.countrycode)) {
+                continue;
+            }
+            countryCodeSet.add(loc.countrycode);
+
             if (today > loc.arrive.toDate()) {
                 visited++;
             }


### PR DESCRIPTION
This just allows me to have each location be a city/place rather than a whole country.